### PR TITLE
Feature/v2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "quorum-vault-client"
-version = "1.0.1"
-edition = "2021"
+version = "2.0.0"
+edition = "2024"
 repository = "https://github.com/MaximFischuk/quorum-vault-client"
 documentation = "https://docs.rs/quorum-vault-client"
 description = "A Rust client for Quorum Vault Plugin"
@@ -10,20 +10,19 @@ readme = "README.md"
 license = "MIT"
 
 [dependencies]
-vaultrs = "0.8.0"
-web3 = "0.19.0"
+vaultrs = "0.8"
 derive_builder = "0.20.2"
 thiserror = "2.0.18"
-log = "0.4.29"
-serde = "1.0.228"
-serde_json = "1.0.149"
+serde = "1"
 rustify = "0.7.0"
 rustify_derive = "0.5.5"
-eth_checksum = "0.1.2"
 base64 = "0.22.1"
 hex = "0.4.3"
+alloy-primitives = { version = "1", features = ["serde"] }
+alloy-rpc-types-eth = { version = "1", features = ["serde"] }
 
 [dev-dependencies]
 tokio = { version = "1.51.0", features = ["full"] }
 wiremock = "0.6.5"
+serde_json = "1.0.149"
 secp256k1 = "0.31.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ license = "MIT"
 vaultrs = "0.8"
 derive_builder = "0.20.2"
 thiserror = "2.0.18"
-serde = "1"
+serde = { version = "1", features = ["derive"] }
 rustify = "0.7.0"
 rustify_derive = "0.5.5"
 base64 = "0.22.1"

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The following backends are supported:
 Add the following to your `Cargo.toml`:
 ```toml
 [dependencies]
-quorum-vault-client = "1.0.0"
+quorum-vault-client = "2.0.0"
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ The following backends are supported:
     * Delete Key
     * Sign Data
     * Import Private Key
+    * Update Key Tags
 * ZK-SNARKs
     * Create ZK-SNARKs Account
     * Read ZK-SNARKs Account
@@ -114,7 +115,6 @@ quorum_vault_client::api::ethereum::import_private_key(
 ).await.unwrap();
 
 // v2.0
-use std::str::FromStr;
 use quorum_vault_client::B256;
 
 let private_key: B256 = "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
@@ -127,7 +127,7 @@ quorum_vault_client::api::ethereum::import_private_key(
 
 ### 5. API module paths
 
-API functions are organized under submodules. Ensure you use the full path:
+API functions are now organized under explicit submodules. Update all call sites:
 
 ```rust
 // Ethereum
@@ -143,10 +143,12 @@ quorum_vault_client::api::keys::create_key(&client, "quorum", id, algorithm, tag
 quorum_vault_client::api::keys::read_key(&client, "quorum", id).await?;
 quorum_vault_client::api::keys::list_keys(&client, "quorum").await?;
 quorum_vault_client::api::keys::destroy_key(&client, "quorum", id).await?;
+quorum_vault_client::api::keys::import_key(&client, "quorum", id, algorithm, tags, private_key).await?;
+quorum_vault_client::api::keys::update_key_tags(&client, "quorum", id, tags).await?;
 quorum_vault_client::api::keys::sign(&client, "quorum", id, data).await?;
 quorum_vault_client::api::keys::sign_hash(&client, "quorum", id, hash).await?;
 
-// ZK-SNARKs (new)
+// ZK-SNARKs (new in v2.0)
 quorum_vault_client::api::zksnarks::create_zksnarks_account(&client, "quorum").await?;
 quorum_vault_client::api::zksnarks::read_zksnarks_account(&client, "quorum", id).await?;
 quorum_vault_client::api::zksnarks::list_zksnarks_accounts(&client, "quorum").await?;
@@ -158,7 +160,7 @@ quorum_vault_client::api::zksnarks::zksnarks_sign_hash(&client, "quorum", id, ha
 
 - **ZK-SNARKs support** — Full API for creating, reading, listing zk-SNARKs (EdDSA/BabyJubJub) accounts and signing data.
 - **`sign` function for Ethereum** — Sign arbitrary data with an Ethereum account.
-- **`sign_hash` functions** — Both Keys and ZK-SNARKs modules now provide `sign_hash` for signing pre-computed 32-byte digests (bypassing internal keccak256 hashing).
+- **`sign_hash` functions** — Both Keys and ZK-SNARKs modules now provide `sign_hash` for signing pre-computed 32-byte digests, bypassing internal keccak256 hashing.
 - **`update_key_tags`** — Update metadata tags on an existing key.
 
 ## Installation
@@ -212,10 +214,9 @@ async fn main() {
     ).unwrap();
 
     // By default the plugin mounts the Ethereum backend at the path "quorum"
-    let created_account = quorum_vault_client::api::create_account(&client, "quorum").await.unwrap();
+    let created_account = quorum_vault_client::api::ethereum::create_account(&client, "quorum").await.unwrap();
     println!("result: {:?}", created_account);
 }
-
 ```
 
 Result of the execution is the following:
@@ -241,10 +242,9 @@ async fn main() {
             .unwrap()
     ).unwrap();
 
-    let list_accounts = quorum_vault_client::api::list_accounts(&client, "quorum").await.unwrap();
+    let list_accounts = quorum_vault_client::api::ethereum::list_accounts(&client, "quorum").await.unwrap();
     println!("result: {:?}", list_accounts);
 }
-
 ```
 
 Result of the execution is the following:
@@ -273,10 +273,9 @@ async fn main() {
     ).unwrap();
 
     let address = Address::from_str("0x8d3113e29CB92F44F1762E52D2a0276509b36b82").unwrap();
-    let read_account = quorum_vault_client::api::read_account(&client, "quorum", account).await.unwrap();
+    let read_account = quorum_vault_client::api::ethereum::read_account(&client, "quorum", address).await.unwrap();
     println!("result: {:?}", read_account);
 }
-
 ```
 
 Result of the execution is the following:
@@ -287,7 +286,7 @@ Result of the execution is the following:
 
 **Sign Ethereum Transaction**
 
-The following example signs the Ethereum Transaction.
+The following example signs an Ethereum Transaction.
 
 ```rust
 use quorum_vault_client::{Client, VaultClient, VaultClientSettingsBuilder, TransactionRequest, Address, U256};
@@ -305,37 +304,31 @@ async fn main() {
     ).unwrap();
 
     let address = Address::from_str("0x8d3113e29CB92F44F1762E52D2a0276509b36b82").unwrap();
-    let mut tx: TransactionRequest = TransactionRequest::builder()
+    let tx = TransactionRequest::default()
         .from(address)
         .to(address)
-        .value(U256::from_dec_str("1000000000000000000").unwrap())
-        .gas(U256::from(21000))
-        .nonce(U256::from(0))
-        .build();
+        .value(U256::from_str("1000000000000000000").unwrap())
+        .gas_limit(21000)
+        .gas_price(1)
+        .nonce(0);
 
-    tx.gas_price = Some(U256::from(1));
-
-    let sign_transaction = quorum_vault_client::api::sign_transaction(&client, "quorum", 1, tx).await.unwrap();
+    let sign_transaction = quorum_vault_client::api::ethereum::sign_transaction(&client, "quorum", 1, tx).await.unwrap();
     println!("result: {:?}", sign_transaction);
 }
-
 ```
 
 Result of the execution is the following:
 
 ```bash
-> signature: EthereumSignTransactionResponse { signature: "0xf29001752503d05ae83874193a8d866d49fc897c1a2fcb6229a0c61e4b5663f7097817a26f4c6014bbfd24c484bad9587c9c627c6f70d020f8638a4067bb78e801" }
+> result: EthereumSignTransactionResponse { signature: "0xf29001752503d05ae83874193a8d866d49fc897c1a2fcb6229a0c61e4b5663f7097817a26f4c6014bbfd24c484bad9587c9c627c6f70d020f8638a4067bb78e801" }
 ```
 
-### Keys
+**Import Private Key**
 
-**Create Key**
-
-The following example creates a new key in the Vault.
+The following example imports an existing private key into the Vault as a new Ethereum account.
 
 ```rust
-use quorum_vault_client::{Client, VaultClient, VaultClientSettingsBuilder};
-use quorum_vault_client::api::KeyCryptoAlgorithm;
+use quorum_vault_client::{Client, VaultClient, VaultClientSettingsBuilder, B256};
 
 #[tokio::main]
 async fn main() {
@@ -348,8 +341,79 @@ async fn main() {
             .unwrap()
     ).unwrap();
 
-    let created_key = quorum_vault_client::api::create_key(&client, "quorum", "some-id", KeyCryptoAlgorithm::Secp256k1, [("tag".to_string(), "value".to_string())].into_iter().collect()).await.unwrap();
+    let private_key: B256 = "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
+        .parse()
+        .unwrap();
+    let account = quorum_vault_client::api::ethereum::import_private_key(&client, "quorum", private_key).await.unwrap();
+    println!("result: {:?}", account);
+}
+```
 
+Result of the execution is the following:
+
+```bash
+> result: EthereumAccountResponse { address: 0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266, compressed_public_key: "0x...", public_key: "0x...", namespace: "" }
+```
+
+**Sign Arbitrary Data**
+
+The following example signs arbitrary data with an Ethereum account.
+
+```rust
+use quorum_vault_client::{Client, VaultClient, VaultClientSettingsBuilder, Address};
+use std::str::FromStr;
+
+#[tokio::main]
+async fn main() {
+    // Create a client
+    let client = VaultClient::new(
+        VaultClientSettingsBuilder::default()
+            .address("https://127.0.0.1:8200")
+            .token("TOKEN")
+            .build()
+            .unwrap()
+    ).unwrap();
+
+    let address = Address::from_str("0x8d3113e29CB92F44F1762E52D2a0276509b36b82").unwrap();
+    let signature = quorum_vault_client::api::ethereum::sign(&client, "quorum", address, b"some-data").await.unwrap();
+    println!("result: {:?}", signature);
+}
+```
+
+Result of the execution is the following:
+
+```bash
+> result: EthereumSignResponse { signature: "0x..." }
+```
+
+### Keys
+
+**Create Key**
+
+The following example creates a new key in the Vault.
+
+```rust
+use quorum_vault_client::{Client, VaultClient, VaultClientSettingsBuilder};
+use quorum_vault_client::api::keys::KeyCryptoAlgorithm;
+
+#[tokio::main]
+async fn main() {
+    // Create a client
+    let client = VaultClient::new(
+        VaultClientSettingsBuilder::default()
+            .address("https://127.0.0.1:8200")
+            .token("TOKEN")
+            .build()
+            .unwrap()
+    ).unwrap();
+
+    let created_key = quorum_vault_client::api::keys::create_key(
+        &client,
+        "quorum",
+        "some-id",
+        KeyCryptoAlgorithm::Secp256k1,
+        [("tag".to_string(), "value".to_string())].into_iter().collect(),
+    ).await.unwrap();
     println!("result: {:?}", created_key);
 }
 ```
@@ -357,7 +421,7 @@ async fn main() {
 Result of the execution is the following:
 
 ```bash
-> result: KeyResponse { created_at: "2023-01-30T09:08:22.217224856Z", curve: "secp256k1", id: "some-id", namespace: "", public_key: "BIwm5UiSGTiXVRlB_rS7qYSzQ6XZbaWfUOJKVicU85q-N7zuAak2JQfAHUs2Sm2WAA7YyWdN7_4UFJFggEa6AKw=", signing_algorithm: "ecdsa", tags: {"tag": "value0"}, updated_at: "2023-01-30T09:08:22.217224856Z", version: 1 }
+> result: KeyResponse { created_at: "2023-01-30T09:08:22.217224856Z", curve: "secp256k1", id: "some-id", namespace: "", public_key: "BIwm5UiSGTiXVRlB_rS7qYSzQ6XZbaWfUOJKVicU85q-N7zuAak2JQfAHUs2Sm2WAA7YyWdN7_4UFJFggEa6AKw=", signing_algorithm: "ecdsa", tags: {"tag": "value"}, updated_at: "2023-01-30T09:08:22.217224856Z", version: 1 }
 ```
 
 **Read Key**
@@ -369,16 +433,16 @@ use quorum_vault_client::{Client, VaultClient, VaultClientSettingsBuilder};
 
 #[tokio::main]
 async fn main() {
-  // Create a client
-  let client = VaultClient::new(
-    VaultClientSettingsBuilder::default()
+    // Create a client
+    let client = VaultClient::new(
+        VaultClientSettingsBuilder::default()
             .address("https://127.0.0.1:8200")
             .token("TOKEN")
             .build()
             .unwrap()
-  ).unwrap();
+    ).unwrap();
 
-  let key = quorum_vault_client::api::read_key(&client, "quorum", "some-id").await.unwrap();
+    let key = quorum_vault_client::api::keys::read_key(&client, "quorum", "some-id").await.unwrap();
     println!("result: {:?}", key);
 }
 ```
@@ -386,7 +450,7 @@ async fn main() {
 Result of the execution is the following:
 
 ```bash
-> result: KeyResponse { created_at: "2023-01-30T09:08:22.217224856Z", curve: "secp256k1", id: "some-id", namespace: "", public_key: "BIwm5UiSGTiXVRlB_rS7qYSzQ6XZbaWfUOJKVicU85q-N7zuAak2JQfAHUs2Sm2WAA7YyWdN7_4UFJFggEa6AKw=", signing_algorithm: "ecdsa", tags: {"tag": "value0"}, updated_at: "2023-01-30T09:08:22.217224856Z", version: 1 }
+> result: KeyResponse { created_at: "2023-01-30T09:08:22.217224856Z", curve: "secp256k1", id: "some-id", namespace: "", public_key: "BIwm5UiSGTiXVRlB_rS7qYSzQ6XZbaWfUOJKVicU85q-N7zuAak2JQfAHUs2Sm2WAA7YyWdN7_4UFJFggEa6AKw=", signing_algorithm: "ecdsa", tags: {"tag": "value"}, updated_at: "2023-01-30T09:08:22.217224856Z", version: 1 }
 ```
 
 **List Keys**
@@ -398,17 +462,17 @@ use quorum_vault_client::{Client, VaultClient, VaultClientSettingsBuilder};
 
 #[tokio::main]
 async fn main() {
-  // Create a client
-  let client = VaultClient::new(
-    VaultClientSettingsBuilder::default()
+    // Create a client
+    let client = VaultClient::new(
+        VaultClientSettingsBuilder::default()
             .address("https://127.0.0.1:8200")
             .token("TOKEN")
             .build()
             .unwrap()
-  ).unwrap();
-  
-  let keys = quorum_vault_client::api::list_keys(&client, "quorum").await.unwrap();
-  println!("result: {:?}", keys);
+    ).unwrap();
+
+    let keys = quorum_vault_client::api::keys::list_keys(&client, "quorum").await.unwrap();
+    println!("result: {:?}", keys);
 }
 ```
 
@@ -427,39 +491,39 @@ use quorum_vault_client::{Client, VaultClient, VaultClientSettingsBuilder};
 
 #[tokio::main]
 async fn main() {
-  // Create a client
-  let client = VaultClient::new(
-    VaultClientSettingsBuilder::default()
+    // Create a client
+    let client = VaultClient::new(
+        VaultClientSettingsBuilder::default()
             .address("https://127.0.0.1:8200")
             .token("TOKEN")
             .build()
             .unwrap()
-  ).unwrap();
+    ).unwrap();
 
-  quorum_vault_client::api::destroy_key(&client, "quorum", "some-id").await.unwrap();
+    quorum_vault_client::api::keys::destroy_key(&client, "quorum", "some-id").await.unwrap();
 }
 ```
 
-**Sign data**
+**Sign Data**
 
-The following example signs the data by key id.
+The following example signs data with a key by its id. The data is hashed with keccak256 before signing.
 
 ```rust
 use quorum_vault_client::{Client, VaultClient, VaultClientSettingsBuilder};
 
 #[tokio::main]
 async fn main() {
-  // Create a client
-  let client = VaultClient::new(
-    VaultClientSettingsBuilder::default()
+    // Create a client
+    let client = VaultClient::new(
+        VaultClientSettingsBuilder::default()
             .address("https://127.0.0.1:8200")
             .token("TOKEN")
             .build()
             .unwrap()
-  ).unwrap();
+    ).unwrap();
 
-  let signature = quorum_vault_client::api::sign(&client, "quorum", "some-id", "some-data".as_bytes().await.unwrap();
-  println!("signature: {:?}", signature);
+    let signature = quorum_vault_client::api::keys::sign(&client, "quorum", "some-id", b"some-data").await.unwrap();
+    println!("signature: {:?}", signature);
 }
 ```
 
@@ -467,4 +531,193 @@ Result of the execution is the following:
 
 ```bash
 > signature: SignResponse { signature: "Z1ibkBIGjMLh5pSR5mFZ5NbesrM57g-FGkFr0sbIyIlI_M0BYVN_LD-Nt7x1wUo6AoLQyL0I-z7PD8MsdgmkhQ==" }
+```
+
+**Import Private Key**
+
+The following example imports an existing private key into the Vault.
+
+```rust
+use quorum_vault_client::{Client, VaultClient, VaultClientSettingsBuilder};
+use quorum_vault_client::api::keys::KeyCryptoAlgorithm;
+
+#[tokio::main]
+async fn main() {
+    // Create a client
+    let client = VaultClient::new(
+        VaultClientSettingsBuilder::default()
+            .address("https://127.0.0.1:8200")
+            .token("TOKEN")
+            .build()
+            .unwrap()
+    ).unwrap();
+
+    let key = quorum_vault_client::api::keys::import_key(
+        &client,
+        "quorum",
+        "some-id",
+        KeyCryptoAlgorithm::Secp256k1,
+        [("tag".to_string(), "value".to_string())].into_iter().collect(),
+        "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80",
+    ).await.unwrap();
+    println!("result: {:?}", key);
+}
+```
+
+Result of the execution is the following:
+
+```bash
+> result: KeyResponse { created_at: "2023-01-30T09:08:22.217224856Z", curve: "secp256k1", id: "some-id", namespace: "", public_key: "BIwm5UiSGTiXVRlB_rS7qYSzQ6XZbaWfUOJKVicU85q-N7zuAak2JQfAHUs2Sm2WAA7YyWdN7_4UFJFggEa6AKw=", signing_algorithm: "ecdsa", tags: {"tag": "value"}, updated_at: "2023-01-30T09:08:22.217224856Z", version: 1 }
+```
+
+**Update Key Tags**
+
+The following example updates the metadata tags of an existing key.
+
+```rust
+use quorum_vault_client::{Client, VaultClient, VaultClientSettingsBuilder};
+
+#[tokio::main]
+async fn main() {
+    // Create a client
+    let client = VaultClient::new(
+        VaultClientSettingsBuilder::default()
+            .address("https://127.0.0.1:8200")
+            .token("TOKEN")
+            .build()
+            .unwrap()
+    ).unwrap();
+
+    let key = quorum_vault_client::api::keys::update_key_tags(
+        &client,
+        "quorum",
+        "some-id",
+        [("env".to_string(), "production".to_string())].into_iter().collect(),
+    ).await.unwrap();
+    println!("result: {:?}", key);
+}
+```
+
+Result of the execution is the following:
+
+```bash
+> result: KeyResponse { created_at: "2023-01-30T09:08:22.217224856Z", curve: "secp256k1", id: "some-id", namespace: "", public_key: "BIwm5UiSGTiXVRlB_rS7qYSzQ6XZbaWfUOJKVicU85q-N7zuAak2JQfAHUs2Sm2WAA7YyWdN7_4UFJFggEa6AKw=", signing_algorithm: "ecdsa", tags: {"env": "production"}, updated_at: "2023-01-30T09:08:22.217224856Z", version: 2 }
+```
+
+### ZK-SNARKs
+
+**Create ZK-SNARKs Account**
+
+The following example creates a new ZK-SNARKs (EdDSA/BabyJubJub) account in the Vault.
+
+```rust
+use quorum_vault_client::{Client, VaultClient, VaultClientSettingsBuilder};
+
+#[tokio::main]
+async fn main() {
+    // Create a client
+    let client = VaultClient::new(
+        VaultClientSettingsBuilder::default()
+            .address("https://127.0.0.1:8200")
+            .token("TOKEN")
+            .build()
+            .unwrap()
+    ).unwrap();
+
+    let account = quorum_vault_client::api::zksnarks::create_zksnarks_account(&client, "quorum").await.unwrap();
+    println!("result: {:?}", account);
+}
+```
+
+Result of the execution is the following:
+
+```bash
+> result: ZkSnarksAccountResponse { curve: "babyjubjub", namespace: "", public_key: "...", signing_algorithm: "eddsa" }
+```
+
+**Read ZK-SNARKs Account**
+
+The following example reads a ZK-SNARKs account by its public key, which is used as the account id.
+
+```rust
+use quorum_vault_client::{Client, VaultClient, VaultClientSettingsBuilder};
+
+#[tokio::main]
+async fn main() {
+    // Create a client
+    let client = VaultClient::new(
+        VaultClientSettingsBuilder::default()
+            .address("https://127.0.0.1:8200")
+            .token("TOKEN")
+            .build()
+            .unwrap()
+    ).unwrap();
+
+    let account = quorum_vault_client::api::zksnarks::read_zksnarks_account(&client, "quorum", "<public-key>").await.unwrap();
+    println!("result: {:?}", account);
+}
+```
+
+Result of the execution is the following:
+
+```bash
+> result: ZkSnarksAccountResponse { curve: "babyjubjub", namespace: "", public_key: "...", signing_algorithm: "eddsa" }
+```
+
+**List ZK-SNARKs Accounts**
+
+The following example lists all ZK-SNARKs accounts in the Vault.
+
+```rust
+use quorum_vault_client::{Client, VaultClient, VaultClientSettingsBuilder};
+
+#[tokio::main]
+async fn main() {
+    // Create a client
+    let client = VaultClient::new(
+        VaultClientSettingsBuilder::default()
+            .address("https://127.0.0.1:8200")
+            .token("TOKEN")
+            .build()
+            .unwrap()
+    ).unwrap();
+
+    let accounts = quorum_vault_client::api::zksnarks::list_zksnarks_accounts(&client, "quorum").await.unwrap();
+    println!("result: {:?}", accounts);
+}
+```
+
+Result of the execution is the following:
+
+```bash
+> result: ZkSnarksAccountsResponse { keys: ["<public-key-1>", "<public-key-2>"] }
+```
+
+**Sign Data**
+
+The following example signs data with a ZK-SNARKs account. The data is hashed with keccak256 before signing.
+
+```rust
+use quorum_vault_client::{Client, VaultClient, VaultClientSettingsBuilder};
+
+#[tokio::main]
+async fn main() {
+    // Create a client
+    let client = VaultClient::new(
+        VaultClientSettingsBuilder::default()
+            .address("https://127.0.0.1:8200")
+            .token("TOKEN")
+            .build()
+            .unwrap()
+    ).unwrap();
+
+    let signature = quorum_vault_client::api::zksnarks::zksnarks_sign(&client, "quorum", "<public-key>", b"some-data").await.unwrap();
+    println!("signature: {:?}", signature);
+}
+```
+
+Result of the execution is the following:
+
+```bash
+> signature: ZkSnarksSignResponse { signature: "..." }
 ```

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ The following backends are supported:
     * Read Ethereum Account by Address
     * Sign Ethereum Transaction (only Legacy)
     * Import Private Key
+    * Sign Arbitrary Data
 * Keys
     * Create Key
     * List Keys
@@ -20,6 +21,145 @@ The following backends are supported:
     * Delete Key
     * Sign Data
     * Import Private Key
+* ZK-SNARKs
+    * Create ZK-SNARKs Account
+    * Read ZK-SNARKs Account
+    * List ZK-SNARKs Accounts
+    * Sign Data
+
+## Migrating to v2.0
+
+Version 2.0 is a major release that replaces the unmaintained [`web3`](https://crates.io/crates/web3) crate with the actively maintained [`alloy`](https://github.com/alloy-rs) ecosystem, updates the Rust edition to **2024**, and introduces stricter typing across the API.
+
+### Breaking Changes at a Glance
+
+| Area | v1.x | v2.0 |
+|---|---|---|
+| **Rust edition** | 2021 | 2024 |
+| **Ethereum types** | `web3 = "0.19"` | `alloy-primitives = "1"` |
+| **Transaction types** | `web3::types::TransactionRequest` | `alloy-rpc-types-eth::TransactionRequest` |
+| **Address checksumming** | `eth_checksum` crate | Built-in `Address::to_checksum(None)` |
+| **Keccak256 hashing** | `web3::signing::keccak256()` | `alloy_primitives::keccak256()` |
+| **Re-exports** | `pub use web3::types::*` | `pub use alloy_primitives::*` |
+
+### 1. Update your `Cargo.toml`
+
+Remove `web3` from your dependencies and add `alloy-primitives` if you use Ethereum primitive types directly:
+
+```toml
+[dependencies]
+quorum-vault-client = "2.0.0"
+# Only needed if you construct alloy types directly:
+# alloy-primitives = "1"
+# alloy-rpc-types-eth = "1"
+```
+
+### 2. Update imports
+
+The crate now re-exports types from `alloy_primitives` instead of `web3::types`:
+
+```rust
+// v1.x
+use quorum_vault_client::{Client, VaultClient, VaultClientSettingsBuilder};
+use web3::types::{Address, U256, TransactionRequest};
+
+// v2.0
+use quorum_vault_client::{Client, VaultClient, VaultClientSettingsBuilder, Address, U256, TransactionRequest};
+```
+
+All commonly used types (`Address`, `U256`, `Bytes`, etc.) keep the same names but come from `alloy_primitives`. If you were importing `web3::types::*` directly, replace those imports with `alloy_primitives::*`.
+
+> **Note:** `H256` from web3 is replaced by `B256` in alloy.
+
+### 3. Update `TransactionRequest` construction
+
+The `TransactionRequest` builder API has changed significantly:
+
+```rust
+// v1.x
+let mut tx = TransactionRequest::builder()
+    .from(address)
+    .to(address)
+    .value(U256::from_dec_str("1000000000000000000").unwrap())
+    .gas(U256::from(21000))
+    .nonce(U256::from(0))
+    .build();
+tx.gas_price = Some(U256::from(1));
+
+// v2.0
+let tx = TransactionRequest::default()
+    .from(address)
+    .to(address)
+    .value(U256::from_str("1000000000000000000").unwrap())
+    .gas_limit(21000)
+    .gas_price(1)
+    .nonce(0);
+```
+
+Key differences:
+- `TransactionRequest::builder().build()` → `TransactionRequest::default()` (no `.build()` call)
+- `.gas(U256)` → `.gas_limit(u64)` — accepts a native integer
+- `.nonce(U256)` → `.nonce(u64)` — accepts a native integer
+- `.gas_price` is now set via the builder chain, not as a mutable field
+- `U256::from_dec_str(...)` → `U256::from_str(...)` (requires `use std::str::FromStr`)
+
+### 4. Update `import_private_key` calls
+
+The `import_private_key` function now accepts `B256` instead of `&str` for type safety:
+
+```rust
+// v1.x
+quorum_vault_client::api::ethereum::import_private_key(
+    &client, "quorum", "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
+).await.unwrap();
+
+// v2.0
+use std::str::FromStr;
+use quorum_vault_client::B256;
+
+let private_key: B256 = "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
+    .parse()
+    .unwrap();
+quorum_vault_client::api::ethereum::import_private_key(
+    &client, "quorum", private_key
+).await.unwrap();
+```
+
+### 5. API module paths
+
+API functions are organized under submodules. Ensure you use the full path:
+
+```rust
+// Ethereum
+quorum_vault_client::api::ethereum::create_account(&client, "quorum").await?;
+quorum_vault_client::api::ethereum::list_accounts(&client, "quorum").await?;
+quorum_vault_client::api::ethereum::read_account(&client, "quorum", address).await?;
+quorum_vault_client::api::ethereum::sign_transaction(&client, "quorum", chain_id, tx).await?;
+quorum_vault_client::api::ethereum::import_private_key(&client, "quorum", private_key).await?;
+quorum_vault_client::api::ethereum::sign(&client, "quorum", address, data).await?;
+
+// Keys
+quorum_vault_client::api::keys::create_key(&client, "quorum", id, algorithm, tags).await?;
+quorum_vault_client::api::keys::read_key(&client, "quorum", id).await?;
+quorum_vault_client::api::keys::list_keys(&client, "quorum").await?;
+quorum_vault_client::api::keys::destroy_key(&client, "quorum", id).await?;
+quorum_vault_client::api::keys::sign(&client, "quorum", id, data).await?;
+quorum_vault_client::api::keys::sign_hash(&client, "quorum", id, hash).await?;
+
+// ZK-SNARKs (new)
+quorum_vault_client::api::zksnarks::create_zksnarks_account(&client, "quorum").await?;
+quorum_vault_client::api::zksnarks::read_zksnarks_account(&client, "quorum", id).await?;
+quorum_vault_client::api::zksnarks::list_zksnarks_accounts(&client, "quorum").await?;
+quorum_vault_client::api::zksnarks::zksnarks_sign(&client, "quorum", id, data).await?;
+quorum_vault_client::api::zksnarks::zksnarks_sign_hash(&client, "quorum", id, hash).await?;
+```
+
+### 6. New features in v2.0
+
+- **ZK-SNARKs support** — Full API for creating, reading, listing zk-SNARKs (EdDSA/BabyJubJub) accounts and signing data.
+- **`sign` function for Ethereum** — Sign arbitrary data with an Ethereum account.
+- **`sign_hash` functions** — Both Keys and ZK-SNARKs modules now provide `sign_hash` for signing pre-computed 32-byte digests (bypassing internal keccak256 hashing).
+- **`update_key_tags`** — Update metadata tags on an existing key.
 
 ## Installation
 Add the following to your `Cargo.toml`:

--- a/examples/ethereum_wallet.rs
+++ b/examples/ethereum_wallet.rs
@@ -1,5 +1,7 @@
+use alloy_primitives::U256;
+use alloy_rpc_types_eth::TransactionRequest;
+use std::str::FromStr;
 use vaultrs::client::{VaultClient, VaultClientSettingsBuilder};
-use web3::types::{TransactionRequest, U256};
 
 #[tokio::main]
 async fn main() {
@@ -29,15 +31,13 @@ async fn main() {
         .unwrap();
     println!("result: {:?}", result);
 
-    let mut tx: TransactionRequest = TransactionRequest::builder()
+    let tx: TransactionRequest = TransactionRequest::default()
         .from(address)
         .to(address)
-        .value(U256::from_dec_str("1000000000000000000").unwrap())
-        .gas(U256::from(21000))
-        .nonce(U256::from(0))
-        .build();
-
-    tx.gas_price = Some(U256::from(1));
+        .value(U256::from_str("1000000000000000000").unwrap())
+        .gas_limit(21000)
+        .gas_price(1)
+        .nonce(0);
 
     let signature = quorum_vault_client::api::ethereum::sign_transaction(&client, "quorum", 1, tx)
         .await

--- a/src/api/ethereum.rs
+++ b/src/api/ethereum.rs
@@ -86,7 +86,7 @@ pub async fn sign_transaction(
         .gas_limit(transaction.gas.unwrap_or(21000))
         .gas_price(transaction.gas_price.unwrap_or_default().to_string())
         .nonce(transaction.nonce.unwrap_or_default())
-        .data(transaction.input.input.unwrap_or_default())
+        .data(transaction.input.into_input().unwrap_or_default())
         .to(to)
         .build()
         .unwrap();

--- a/src/api/ethereum.rs
+++ b/src/api/ethereum.rs
@@ -101,6 +101,7 @@ pub async fn import_private_key(
     mount: &str,
     private_key: B256,
 ) -> Result<EthereumAccountResponse, ClientError> {
+    // The API expects the private key as a hex string without the "0x" prefix
     let private_key_hex = format!("{:x}", private_key);
     let request = ImportPrivateKeyRequest::builder()
         .mount(mount)

--- a/src/api/ethereum.rs
+++ b/src/api/ethereum.rs
@@ -6,9 +6,10 @@ use crate::api::ethereum::responses::{
     EthereumAccountResponse, EthereumAccountsResponse, EthereumSignTransactionResponse,
 };
 
+use alloy_primitives::{Address, B256, TxKind};
+use alloy_rpc_types_eth::TransactionRequest;
 use vaultrs::client::Client;
 use vaultrs::error::ClientError;
-use web3::types::{Address, TransactionRequest};
 
 use self::requests::EthereumSignRequest;
 use self::responses::EthereumSignResponse;
@@ -52,8 +53,7 @@ pub async fn read_account(
     mount: &str,
     address: Address,
 ) -> Result<EthereumAccountResponse, ClientError> {
-    let address = format!("{address:?}");
-    let checksummed = eth_checksum::checksum(&address);
+    let checksummed = address.to_checksum(None);
     let request = ReadEthereumAccountRequest::builder()
         .mount(mount)
         .address(checksummed)
@@ -71,20 +71,26 @@ pub async fn sign_transaction(
     chain_id: u64,
     transaction: TransactionRequest,
 ) -> Result<EthereumSignTransactionResponse, ClientError> {
-    let address = format!("{:?}", transaction.from);
-    let checksummed = eth_checksum::checksum(&address);
+    let checksummed = transaction.from.unwrap_or_default().to_checksum(None);
+    let to = if let Some(TxKind::Call(recipient)) = transaction.to {
+        Some(format!("0x{:x}", recipient))
+    } else {
+        // Contract creation transactions have no recipient address
+        None
+    };
     let request = SignEthereumTransactionRequest::builder()
         .mount(mount)
         .address(checksummed)
         .chain_id(chain_id.to_string())
         .amount(transaction.value.unwrap_or_default().to_string())
-        .gas_limit(transaction.gas.map(|v| v.as_u64()).unwrap_or(21000))
+        .gas_limit(transaction.gas.unwrap_or(21000))
         .gas_price(transaction.gas_price.unwrap_or_default().to_string())
-        .nonce(transaction.nonce.unwrap_or_default().as_u64())
-        .to(format!("{:?}", transaction.to.unwrap_or_default()))
-        .data(transaction.data.unwrap_or_default())
+        .nonce(transaction.nonce.unwrap_or_default())
+        .data(transaction.input.input.unwrap_or_default())
+        .to(to)
         .build()
         .unwrap();
+
     vaultrs::api::exec_with_result(client, request).await
 }
 
@@ -93,11 +99,12 @@ pub async fn sign_transaction(
 pub async fn import_private_key(
     client: &impl Client,
     mount: &str,
-    private_key: &str,
+    private_key: B256,
 ) -> Result<EthereumAccountResponse, ClientError> {
+    let private_key_hex = format!("{:x}", private_key);
     let request = ImportPrivateKeyRequest::builder()
         .mount(mount)
-        .private_key(private_key)
+        .private_key(private_key_hex)
         .build()
         .unwrap();
     vaultrs::api::exec_with_result(client, request).await
@@ -111,8 +118,7 @@ pub async fn sign(
     address: Address,
     data: &[u8],
 ) -> Result<EthereumSignResponse, ClientError> {
-    let address = format!("{address:?}");
-    let checksummed = eth_checksum::checksum(&address);
+    let checksummed = address.to_checksum(None);
     let request = EthereumSignRequest::builder()
         .mount(mount)
         .address(checksummed)

--- a/src/api/ethereum/requests.rs
+++ b/src/api/ethereum/requests.rs
@@ -2,8 +2,8 @@ use crate::api::ethereum::responses::{
     EthereumAccountResponse, EthereumAccountsResponse, EthereumSignResponse,
     EthereumSignTransactionResponse,
 };
+use alloy_primitives::Bytes;
 use rustify_derive::Endpoint;
-use web3::types::Bytes;
 
 /// ## Create Ethereum Account
 /// This endpoint creates a new Ethereum account.
@@ -97,7 +97,7 @@ pub struct SignEthereumTransactionRequest {
     #[endpoint(body)]
     pub nonce: u64,
     #[endpoint(body)]
-    pub to: String,
+    pub to: Option<String>,
 }
 
 /// ## Import Private Key

--- a/src/api/ethereum/responses.rs
+++ b/src/api/ethereum/responses.rs
@@ -1,5 +1,5 @@
+use alloy_primitives::Address;
 use serde::{Deserialize, Serialize};
-use web3::types::Address;
 
 /// Response from executing
 /// [ReadEthereumAccountRequest][crate::api::ethereum::requests::ReadEthereumAccountRequest]

--- a/src/api/keys.rs
+++ b/src/api/keys.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 
+use alloy_primitives::keccak256;
 use base64::Engine;
 use vaultrs::client::Client;
 use vaultrs::error::ClientError;
@@ -137,7 +138,7 @@ pub async fn sign(
     id: &str,
     data: &[u8],
 ) -> Result<SignResponse, ClientError> {
-    let hash = web3::signing::keccak256(data);
+    let hash = keccak256(data);
     let encoded = base64::prelude::BASE64_URL_SAFE.encode(hash);
     let request = SignRequest::builder()
         .mount(mount)

--- a/src/api/zksnarks.rs
+++ b/src/api/zksnarks.rs
@@ -6,7 +6,7 @@ use crate::api::zksnarks::responses::{
     ZkSnarksAccountResponse, ZkSnarksAccountsResponse, ZkSnarksSignResponse,
 };
 use crate::error::ClientError;
-use crate::H256;
+use alloy_primitives::{B256, keccak256};
 use vaultrs::client::Client;
 
 pub mod requests;
@@ -67,9 +67,8 @@ pub async fn zksnarks_sign(
     id: &str,
     data: &[u8],
 ) -> Result<ZkSnarksSignResponse, ClientError> {
-    let hash = web3::signing::keccak256(data);
-    let hex = H256::from(hash);
-    let encoded = format!("{:?}", hex);
+    let hash = keccak256(data);
+    let encoded = format!("0x{:x}", hash);
     let request = ZkSnarksSignRequest::builder()
         .mount(mount)
         .id(id)
@@ -90,8 +89,8 @@ pub async fn zksnarks_sign_hash(
     id: &str,
     data: [u8; 32],
 ) -> Result<ZkSnarksSignResponse, ClientError> {
-    let hex = H256::from(data);
-    let encoded = format!("{:?}", hex);
+    let hex = B256::from(data);
+    let encoded = format!("0x{:x}", hex);
     let request = ZkSnarksSignRequest::builder()
         .mount(mount)
         .id(id)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,7 @@
 //! Add the following to your `Cargo.toml`:
 //! ```toml
 //! [dependencies]
-//! quorum-vault-client = "0.1.0"
+//! quorum-vault-client = "2.0.0"
 //! ```
 //!
 //! ## Usage
@@ -180,7 +180,7 @@
 //! Result of the execution is the following:
 //!
 //! ```bash
-//! > signature: EthereumSignTransactionResponse { signature: "0xf29001752503d05ae83874193a8d866d49fc897c1a2fcb6229a0c61e4b5663f7097817a26f4c6014bbfd24c484bad9587c9c627c6f70d020f8638a4067bb78e801" }
+//! > result: EthereumSignTransactionResponse { signature: "0xf29001752503d05ae83874193a8d866d49fc897c1a2fcb6229a0c61e4b5663f7097817a26f4c6014bbfd24c484bad9587c9c627c6f70d020f8638a4067bb78e801" }
 //! ```
 //!
 //! ### Keys
@@ -213,7 +213,7 @@
 //! Result of the execution is the following:
 //!
 //! ```bash
-//! > result: KeyResponse { created_at: "2023-01-30T09:08:22.217224856Z", curve: "secp256k1", id: "some-id", namespace: "", public_key: "BIwm5UiSGTiXVRlB_rS7qYSzQ6XZbaWfUOJKVicU85q-N7zuAak2JQfAHUs2Sm2WAA7YyWdN7_4UFJFggEa6AKw=", signing_algorithm: "ecdsa", tags: {"tag": "value0"}, updated_at: "2023-01-30T09:08:22.217224856Z", version: 1 }
+//! > result: KeyResponse { created_at: "2023-01-30T09:08:22.217224856Z", curve: "secp256k1", id: "some-id", namespace: "", public_key: "BIwm5UiSGTiXVRlB_rS7qYSzQ6XZbaWfUOJKVicU85q-N7zuAak2JQfAHUs2Sm2WAA7YyWdN7_4UFJFggEa6AKw=", signing_algorithm: "ecdsa", tags: {"tag": "value"}, updated_at: "2023-01-30T09:08:22.217224856Z", version: 1 }
 //! ```
 //!
 //! **Read Key**
@@ -225,16 +225,16 @@
 //!
 //! #[tokio::main]
 //! async fn main() {
-//!   // Create a client
-//!   let client = VaultClient::new(
-//!     VaultClientSettingsBuilder::default()
+//!     // Create a client
+//!     let client = VaultClient::new(
+//!         VaultClientSettingsBuilder::default()
 //!             .address("https://127.0.0.1:8200")
 //!             .token("TOKEN")
 //!             .build()
 //!             .unwrap()
-//!   ).unwrap();
+//!     ).unwrap();
 //!
-//!   let key = quorum_vault_client::api::keys::read_key(&client, "quorum", "some-id").await.unwrap();
+//!     let key = quorum_vault_client::api::keys::read_key(&client, "quorum", "some-id").await.unwrap();
 //!     println!("result: {:?}", key);
 //! }
 //! ```
@@ -242,7 +242,7 @@
 //! Result of the execution is the following:
 //!
 //! ```bash
-//! > result: KeyResponse { created_at: "2023-01-30T09:08:22.217224856Z", curve: "secp256k1", id: "some-id", namespace: "", public_key: "BIwm5UiSGTiXVRlB_rS7qYSzQ6XZbaWfUOJKVicU85q-N7zuAak2JQfAHUs2Sm2WAA7YyWdN7_4UFJFggEa6AKw=", signing_algorithm: "ecdsa", tags: {"tag": "value0"}, updated_at: "2023-01-30T09:08:22.217224856Z", version: 1 }
+//! > result: KeyResponse { created_at: "2023-01-30T09:08:22.217224856Z", curve: "secp256k1", id: "some-id", namespace: "", public_key: "BIwm5UiSGTiXVRlB_rS7qYSzQ6XZbaWfUOJKVicU85q-N7zuAak2JQfAHUs2Sm2WAA7YyWdN7_4UFJFggEa6AKw=", signing_algorithm: "ecdsa", tags: {"tag": "value"}, updated_at: "2023-01-30T09:08:22.217224856Z", version: 1 }
 //! ```
 //!
 //! **List Keys**
@@ -254,17 +254,17 @@
 //!
 //! #[tokio::main]
 //! async fn main() {
-//!   // Create a client
-//!   let client = VaultClient::new(
-//!     VaultClientSettingsBuilder::default()
+//!     // Create a client
+//!     let client = VaultClient::new(
+//!         VaultClientSettingsBuilder::default()
 //!             .address("https://127.0.0.1:8200")
 //!             .token("TOKEN")
 //!             .build()
 //!             .unwrap()
-//!   ).unwrap();
+//!     ).unwrap();
 //!
-//!   let keys = quorum_vault_client::api::keys::list_keys(&client, "quorum").await.unwrap();
-//!   println!("result: {:?}", keys);
+//!     let keys = quorum_vault_client::api::keys::list_keys(&client, "quorum").await.unwrap();
+//!     println!("result: {:?}", keys);
 //! }
 //! ```
 //!
@@ -283,16 +283,16 @@
 //!
 //! #[tokio::main]
 //! async fn main() {
-//!   // Create a client
-//!   let client = VaultClient::new(
-//!     VaultClientSettingsBuilder::default()
+//!     // Create a client
+//!     let client = VaultClient::new(
+//!         VaultClientSettingsBuilder::default()
 //!             .address("https://127.0.0.1:8200")
 //!             .token("TOKEN")
 //!             .build()
 //!             .unwrap()
-//!   ).unwrap();
+//!     ).unwrap();
 //!
-//!   quorum_vault_client::api::keys::destroy_key(&client, "quorum", "some-id").await.unwrap();
+//!     quorum_vault_client::api::keys::destroy_key(&client, "quorum", "some-id").await.unwrap();
 //! }
 //! ```
 //!
@@ -305,17 +305,17 @@
 //!
 //! #[tokio::main]
 //! async fn main() {
-//!   // Create a client
-//!   let client = VaultClient::new(
-//!     VaultClientSettingsBuilder::default()
+//!     // Create a client
+//!     let client = VaultClient::new(
+//!         VaultClientSettingsBuilder::default()
 //!             .address("https://127.0.0.1:8200")
 //!             .token("TOKEN")
 //!             .build()
 //!             .unwrap()
-//!   ).unwrap();
+//!     ).unwrap();
 //!
-//!   let signature = quorum_vault_client::api::keys::sign(&client, "quorum", "some-id", "some-data".as_bytes()).await.unwrap();
-//!   println!("signature: {:?}", signature);
+//!     let signature = quorum_vault_client::api::keys::sign(&client, "quorum", "some-id", "some-data".as_bytes()).await.unwrap();
+//!     println!("signature: {:?}", signature);
 //! }
 //! ```
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -163,15 +163,13 @@
 //!     ).unwrap();
 //!
 //!     let address = Address::from_str("0x8d3113e29CB92F44F1762E52D2a0276509b36b82").unwrap();
-//!     let mut tx: TransactionRequest = TransactionRequest::builder()
+//!     let tx: TransactionRequest = TransactionRequest::default()
 //!         .from(address)
 //!         .to(address)
-//!         .value(U256::from_dec_str("1000000000000000000").unwrap())
-//!         .gas(U256::from(21000))
-//!         .nonce(U256::from(0))
-//!         .build();
-//!
-//!     tx.gas_price = Some(U256::from(1));
+//!         .value(U256::from_str("1000000000000000000").unwrap())
+//!         .gas_limit(21000)
+//!         .gas_price(1)
+//!         .nonce(0);
 //!
 //!     let sign_transaction = quorum_vault_client::api::ethereum::sign_transaction(&client, "quorum", 1, tx).await.unwrap();
 //!     println!("result: {:?}", sign_transaction);
@@ -326,6 +324,7 @@
 //! ```bash
 //! > signature: SignResponse { signature: "Z1ibkBIGjMLh5pSR5mFZ5NbesrM57g-FGkFr0sbIyIlI_M0BYVN_LD-Nt7x1wUo6AoLQyL0I-z7PD8MsdgmkhQ==" }
 //! ```
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
 
 pub mod api;
 pub mod error;
@@ -334,5 +333,6 @@ pub mod error;
 extern crate derive_builder;
 
 // re-export
+pub use alloy_primitives::*;
+pub use alloy_rpc_types_eth::TransactionRequest;
 pub use vaultrs::client::{Client, VaultClient, VaultClientSettingsBuilder};
-pub use web3::types::*;

--- a/tests/api/ethereum.rs
+++ b/tests/api/ethereum.rs
@@ -1,7 +1,9 @@
-use quorum_vault_client::api;
 use std::str::FromStr;
+
+use alloy_primitives::{Address, U256};
+use alloy_rpc_types_eth::TransactionRequest;
+use quorum_vault_client::api;
 use vaultrs::client::{VaultClient, VaultClientSettingsBuilder};
-use web3::types::{Address, TransactionRequest, U256};
 use wiremock::matchers::{body_json, method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
@@ -208,15 +210,13 @@ async fn test_sign_transaction() {
     let address = Address::from_str("0xAd38E61dB0D3f8fEF9B4c5DD0C1A9F691cdCcfF5").unwrap();
     let to = Address::from_str("0x1daBe0aCaAA4D1F81b9b43Eaf51C8439378231a0").unwrap();
 
-    let mut tx: TransactionRequest = TransactionRequest::builder()
+    let tx: TransactionRequest = TransactionRequest::default()
         .from(address)
         .to(to)
-        .value(U256::from_dec_str("1000000000000000000").unwrap())
-        .gas(U256::from(21000))
-        .nonce(U256::from(0))
-        .build();
-
-    tx.gas_price = Some(U256::from(1));
+        .value(U256::from_str("1000000000000000000").unwrap())
+        .gas_limit(21000)
+        .gas_price(1)
+        .nonce(0);
 
     let signature = api::ethereum::sign_transaction(&vault_client, "quorum", 1, tx)
         .await
@@ -269,7 +269,9 @@ async fn test_import_private_key() {
     let wallet = api::ethereum::import_private_key(
         &vault_client,
         "quorum",
-        "0a1232595b77534d99364bfde13383accbcb40775967a7eacd15d355c96288a5",
+        "0a1232595b77534d99364bfde13383accbcb40775967a7eacd15d355c96288a5"
+            .parse()
+            .unwrap(),
     )
     .await
     .unwrap();

--- a/tests/api/keys.rs
+++ b/tests/api/keys.rs
@@ -1,7 +1,7 @@
+use alloy_primitives::keccak256;
 use quorum_vault_client::api;
 use quorum_vault_client::api::keys::KeyCryptoAlgorithm;
 use vaultrs::client::{VaultClient, VaultClientSettingsBuilder};
-use web3::signing::keccak256;
 use wiremock::matchers::{body_json, method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
@@ -289,7 +289,7 @@ async fn test_sign_hash() {
         &vault_client,
         "quorum",
         "dd4b594d-4b89-480d-a8a8-01ed7e1f0140",
-        hash,
+        hash.0,
     )
     .await
     .unwrap();

--- a/tests/api/zksnarks.rs
+++ b/tests/api/zksnarks.rs
@@ -1,6 +1,6 @@
+use alloy_primitives::keccak256;
 use quorum_vault_client::api;
 use vaultrs::client::{VaultClient, VaultClientSettingsBuilder};
-use web3::signing::keccak256;
 use wiremock::matchers::{body_json, method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
@@ -242,7 +242,7 @@ async fn test_sign_hash() {
         &vault_client,
         "quorum",
         "0x7e8249b895434a1b02aade22033b887620ab5e756aa106d415ff33ace9048626",
-        hash,
+        hash.0,
     )
     .await
     .unwrap();


### PR DESCRIPTION
This is a **major (v2.0) release**. It replaces the unmaintained `web3` crate with the actively maintained [`alloy`](https://github.com/alloy-rs/alloy) ecosystem, upgrades the Rust edition to 2024, and adds several new API capabilities.

---

#### Breaking Changes

| Area | v1.x | v2.0 |
|---|---|---|
| Rust edition | 2021 | **2024** |
| Ethereum types | `web3::types::*` | `alloy_primitives::*` |
| Transaction type | `web3::types::TransactionRequest` | `alloy_rpc_types_eth::TransactionRequest` |
| Address checksum | `eth_checksum` crate | `Address::to_checksum(None)` (built-in) |
| Keccak256 | `web3::signing::keccak256()` | `alloy_primitives::keccak256()` |
| Re-exports | `pub use web3::types::*` | `pub use alloy_primitives::*` |
| `import_private_key` | accepts `&str` | accepts `B256` (typed, hex-parseable) |
| API module paths | `quorum_vault_client::api::*` | `quorum_vault_client::api::ethereum::*` / `api::keys::*` / `api::zksnarks::*` |
| `H256` | `web3::types::H256` | `alloy_primitives::B256` |

#### New Features

- **ZK-SNARKs support** — Full CRUD API for EdDSA/BabyJubJub accounts: `create_zksnarks_account`, `read_zksnarks_account`, `list_zksnarks_accounts`, `zksnarks_sign`, `zksnarks_sign_hash`
- **`ethereum::sign`** — Sign arbitrary data with an Ethereum account
- **`keys::sign_hash`** and **`zksnarks::sign_hash`** — Sign a pre-computed 32-byte digest, bypassing internal keccak256 hashing
- **`keys::update_key_tags`** — Update metadata tags on an existing key

#### Dependency Changes

- **Removed**: `web3`, `eth_checksum`, `log`
- **Added**: `alloy-primitives = "1"` (with `serde` feature), `alloy-rpc-types-eth = "1"` (with `serde` feature)
- **Moved to dev-deps**: `serde_json`
- **Added to dev-deps**: `secp256k1`
- Added `#![cfg_attr(not(test), warn(unused_crate_dependencies))]` to catch future dependency drift

#### Other Improvements

- `import_private_key` now accepts `B256` instead of a raw `&str`, providing compile-time type safety
- `SignEthereumTransactionRequest.to` is now `Option<String>` to correctly support contract creation transactions (no recipient)
- `TransactionRequest` is now re-exported from the crate root alongside `alloy_primitives::*` types
- README fully rewritten with a migration guide from v1.x